### PR TITLE
Fix unclear issue with columns not uniquely identified

### DIFF
--- a/R/qra.r
+++ b/R/qra.r
@@ -304,6 +304,7 @@ qra <- function(forecasts, data, target_date, min_date, max_date, history,
       dplyr::arrange(quantile) %>%
       dplyr::mutate(quantile =
                       paste0("percentile_", sprintf("%.2f", quantile))) %>%
+      unique() %>%
       tidyr::spread(quantile, weight)
   } else {
     ensemble <- latest_forecasts %>%


### PR DESCRIPTION
We found an issue when trying to use the qra code for the US death forecasts. Somehow (unclear why) there is a problem when having multiple creation dates. The error gets thrown in line 307 (now 308) in `spread(quantile, weight)`, because some columns are not uniquely identified. 
Running the weights through `unique()` once seems to fix the issue. 
However: I don't know what causes the problem and it might be good to investigate this further