### PR TITLE
Fix scoringutils 2.x compatibility

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,7 @@ Imports:
     data.table,
     purrr,
     quantgen,
-    scoringutils
+    scoringutils (>= 2.0.0)
 Suggests:
     knitr,
     rmarkdown,
@@ -32,7 +32,7 @@ Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE, roclets = c("collate", "namespace", "rd",
     "roxyglobals::global_roclet"))
-RoxygenNote: 7.3.2
+RoxygenNote: 7.3.3
 VignetteBuilder: knitr
 Config/roxyglobals/filename: globals.R
 Config/roxyglobals/unique: FALSE

--- a/R/qra.r
+++ b/R/qra.r
@@ -1,9 +1,8 @@
 ##' Create a qra ensemble
 ##'
 ##' @param x input data frame containing \code{model}, \code{quantile_level},
-##'   \code{boundary}, \code{value}, \code{interval} columns.
-##' @param target input data frame
-##'   \code{boundary}, \code{value}, \code{interval} columns.
+##'   \code{observed}, and \code{predicted} columns.
+##' @param target input data frame containing the same columns as \code{x}.
 ##' @return data frame with weights per quantile (which won't vary unless
 ##'   \code{per_quantile_weights} is set to TRUE), per model
 ##' @param per_quantile_weights logical; whether to estimate weights per
@@ -74,11 +73,11 @@ qra_create_ensemble <- function(x, target, per_quantile_weights, intercept,
     quantile_level = unique(x$quantile_level),
     intercept = intercepts
   )
-  return(list(
+  list(
     weights = wtb,
     intercepts = itb,
     ensemble = target_forecast
-  ))
+  )
 }
 
 #' Preprocess forecasts for QRA
@@ -112,19 +111,17 @@ qra_preprocess_forecasts <- function(forecast) {
   pred_matrices <- lapply(pred_matrices, function(x) {
     dt <- dcast(x, ... ~ quantile_level, value.var = "predicted")
     dt[, paste(forecast_unit) := NULL]
-    return(as.matrix(dt))
+    as.matrix(dt)
   })
   ## combine into array
   pred_arrays <- combine_into_array(pred_matrices)
 
   quantile_levels <- unique(forecast$quantile_level)
 
-  return(
-    list(
-      predictions = pred_arrays,
-      data = data,
-      quantile_levels = quantile_levels
-    )
+  list(
+    predictions = pred_arrays,
+    data = data,
+    quantile_levels = quantile_levels
   )
 }
 
@@ -166,12 +163,10 @@ split_forecast <- function(forecast, forecast_unit, target) {
   target_forecast <- forecast[get(names(target)) == target]
   forecast <- forecast[get(names(target)) != target]
 
-  return(
-    list(
-      forecast = forecast,
-      target = target_forecast,
-      models = present_models
-    )
+  list(
+    forecast = forecast,
+    target = target_forecast,
+    models = present_models
   )
 }
 
@@ -255,5 +250,5 @@ qra <- function(forecast, target, group = c(),
   setattr(ret, "models", ensemble[["models"]])
   setattr(ret, "class", c("forecast_quantile", "qra", class(ret)[-1]))
 
-  return(ret)
+  ret
 }

--- a/R/qra.r
+++ b/R/qra.r
@@ -1,6 +1,6 @@
 ##' Create a qra ensemble
 ##'
-##' @param x input data frame containing \code{model}, \code{quantile},
+##' @param x input data frame containing \code{model}, \code{quantile_level},
 ##'   \code{boundary}, \code{value}, \code{interval} columns.
 ##' @param target input data frame
 ##'   \code{boundary}, \code{value}, \code{interval} columns.
@@ -66,12 +66,12 @@ qra_create_ensemble <- function(x, target, per_quantile_weights, intercept,
   ## create return tibbles
   wtb <- CJ(
     model = unique(x$model),
-    quantile = unique(x$quantile_level),
+    quantile_level = unique(x$quantile_level),
     sorted = FALSE
   )[, weight := weights]
 
   itb <- data.table(
-    quantile = unique(x$quantile),
+    quantile_level = unique(x$quantile_level),
     intercept = intercepts
   )
   return(list(

--- a/man/qra_create_ensemble.Rd
+++ b/man/qra_create_ensemble.Rd
@@ -16,10 +16,9 @@ qra_create_ensemble(
 }
 \arguments{
 \item{x}{input data frame containing \code{model}, \code{quantile_level},
-\code{boundary}, \code{value}, \code{interval} columns.}
+\code{observed}, and \code{predicted} columns.}
 
-\item{target}{input data frame
-\code{boundary}, \code{value}, \code{interval} columns.}
+\item{target}{input data frame containing the same columns as \code{x}.}
 
 \item{per_quantile_weights}{logical; whether to estimate weights per
 quantile}

--- a/man/qra_create_ensemble.Rd
+++ b/man/qra_create_ensemble.Rd
@@ -15,7 +15,7 @@ qra_create_ensemble(
 )
 }
 \arguments{
-\item{x}{input data frame containing \code{model}, \code{quantile},
+\item{x}{input data frame containing \code{model}, \code{quantile_level},
 \code{boundary}, \code{value}, \code{interval} columns.}
 
 \item{target}{input data frame


### PR DESCRIPTION
Closes #38

- Update column names from `quantile` to `quantile_level` in internal weight/intercept tables
- Fix reference to `x$quantile` (which doesn't exist) to `x$quantile_level`
- Require scoringutils >= 2.0.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Dependencies**
  * Updated scoringutils dependency to require version 2.0.0 or higher.

* **Documentation**
  * Standardised parameter naming from "quantile" to "quantile_level" across documentation and output labelling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->